### PR TITLE
tiptapText(): support chaining with other field methods

### DIFF
--- a/index.php
+++ b/index.php
@@ -52,11 +52,13 @@ Kirby::plugin('medienbaecker/tiptap', [
 				$options['uuid'] = Field::getUuidConfig();
 			}
 
-			return convertTiptapToHtml(
+			$field->value = convertTiptapToHtml(
 				$field->value,
 				$field->parent(),
 				$options
 			);
+
+			return $field;
 		}
 	],
 	'translations' => A::keyBy(


### PR DESCRIPTION
Set the $field->value and return the $field instead of returning the html string.

Use case:

```yml
placeholder: "{{ page.location.toPage.address.tiptapText.excerpt(1000) }}"
```

Using `excerpt` here to strip html tags.